### PR TITLE
fix: Correct PyQt5 dependencies for Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
   "name": "PyQt5 Codespace",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
-  "onCreateCommand": "pip install PyQt5 && apt-get update && apt-get install -y libgl1-mesa-glx",
+  "postCreateCommand": "pip install -r requirements.txt",
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y libgl1-mesa-glx libegl1-mesa libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 qtwayland5",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
The PyQt5 application was failing to run in GitHub Codespaces due to missing system dependencies.

This change updates the .devcontainer/devcontainer.json file to:
1. Install the necessary Qt and X11 system libraries using apt-get.
2. Use the postCreateCommand to install Python dependencies from requirements.txt, which is a more robust approach.