### PR TITLE
fix: Correct package names for PyQt5 dependencies

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,7 @@
   "name": "PyQt5 Codespace",
   "image": "mcr.microsoft.com/devcontainers/python:3.11",
   "postCreateCommand": "pip install -r requirements.txt",
-  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y libgl1-mesa-glx libegl1-mesa libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 qtwayland5",
+  "onCreateCommand": "sudo apt-get update && sudo apt-get install -y libgl1-mesa-dri libegl1 libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 libxcb-shape0 qtwayland5",
   "customizations": {
     "vscode": {
       "extensions": [


### PR DESCRIPTION
This commit corrects the package names for the system-level dependencies required by PyQt5 in the .devcontainer/devcontainer.json file.

The previous commit used obsolete package names (`libgl1-mesa-glx`, `libegl1-mesa`), which caused the Codespace rebuild to fail. This commit replaces them with the correct, current package names (`libgl1-mesa-dri`, `libegl1`).